### PR TITLE
FEATURE: 2FA on login

### DIFF
--- a/service/queries/authOTP.js
+++ b/service/queries/authOTP.js
@@ -1,0 +1,45 @@
+import { getDBPool } from "#utils/dbConfig";
+
+export const storeAuthOTP = async (poolCountry, admin_id, otp) =>
+  await getDBPool("masterDb", poolCountry).query(
+    `
+        INSERT INTO auth_otp (otp, admin_id)
+        VALUES ($1, $2)
+        RETURNING *;
+    `,
+    [otp, admin_id]
+  );
+
+export const getAuthOTP = async (poolCountry, otp, admin_id) =>
+  await getDBPool("masterDb", poolCountry).query(
+    `
+        SELECT *
+        FROM auth_otp
+        WHERE otp = $1 
+          AND admin_id = $2
+          AND used = false;
+    `,
+    [otp, admin_id]
+  );
+
+export const getUserLastAuthOTP = async (poolCountry, admin_id) =>
+  await getDBPool("masterDb", poolCountry).query(
+    `
+        SELECT *
+        FROM auth_otp
+        WHERE admin_id = $1
+        ORDER BY created_at DESC
+        LIMIT 1;
+    `,
+    [admin_id]
+  );
+
+export const changeOTPToUsed = async (poolCountry, otp_id) =>
+  await getDBPool("masterDb", poolCountry).query(
+    `
+        UPDATE auth_otp
+        SET used = true
+        WHERE id = $1;
+    `,
+    [otp_id]
+  );

--- a/service/queries/authOTP.js
+++ b/service/queries/authOTP.js
@@ -1,7 +1,7 @@
 import { getDBPool } from "#utils/dbConfig";
 
-export const storeAuthOTP = async (poolCountry, admin_id, otp) =>
-  await getDBPool("masterDb", poolCountry).query(
+export const storeAuthOTP = async (admin_id, otp) =>
+  await getDBPool("masterDb").query(
     `
         INSERT INTO auth_otp (otp, admin_id)
         VALUES ($1, $2)
@@ -10,8 +10,8 @@ export const storeAuthOTP = async (poolCountry, admin_id, otp) =>
     [otp, admin_id]
   );
 
-export const getAuthOTP = async (poolCountry, otp, admin_id) =>
-  await getDBPool("masterDb", poolCountry).query(
+export const getAuthOTP = async (otp, admin_id) =>
+  await getDBPool("masterDb").query(
     `
         SELECT *
         FROM auth_otp
@@ -22,8 +22,8 @@ export const getAuthOTP = async (poolCountry, otp, admin_id) =>
     [otp, admin_id]
   );
 
-export const getUserLastAuthOTP = async (poolCountry, admin_id) =>
-  await getDBPool("masterDb", poolCountry).query(
+export const getAdminLastAuthOTP = async (admin_id) =>
+  await getDBPool("masterDb").query(
     `
         SELECT *
         FROM auth_otp
@@ -34,8 +34,8 @@ export const getUserLastAuthOTP = async (poolCountry, admin_id) =>
     [admin_id]
   );
 
-export const changeOTPToUsed = async (poolCountry, otp_id) =>
-  await getDBPool("masterDb", poolCountry).query(
+export const changeOTPToUsed = async (otp_id) =>
+  await getDBPool("masterDb").query(
     `
         UPDATE auth_otp
         SET used = true

--- a/service/routes/v1/authRouter.js
+++ b/service/routes/v1/authRouter.js
@@ -83,4 +83,17 @@ router.post("/refresh-token", async (req, res, next) => {
     .catch(next);
 });
 
+router.post(
+  "/2fa",
+  passport.authenticate("2fa-request", { session: false }),
+  async (req, res) => {
+    /**
+     * #route   POST /admin/v1/auth/2fa
+     * #desc    Request 2fa OTP
+     */
+
+    return res.status(200).send(req.user);
+  }
+);
+
 export { router };

--- a/service/schemas/authSchemas.js
+++ b/service/schemas/authSchemas.js
@@ -14,6 +14,7 @@ export const adminLoginSchema = yup.object().shape({
   email: yup.string().email().required(),
   password: yup.string().required(),
   role: yup.string().oneOf(["global", "country", "regional"]).required(),
+  otp: yup.string().length(4).required(),
 });
 
 export const createAdminSchema = (language) =>
@@ -42,3 +43,8 @@ export const createAdminSchema = (language) =>
     },
     ["adminCountryId", "adminRegionId"]
   );
+
+export const admin2FARequestSchema = yup.object().shape({
+  password: yup.string().required(),
+  email: yup.string().email().required(),
+});

--- a/service/schemas/authSchemas.js
+++ b/service/schemas/authSchemas.js
@@ -47,4 +47,5 @@ export const createAdminSchema = (language) =>
 export const admin2FARequestSchema = yup.object().shape({
   password: yup.string().required(),
   email: yup.string().email().required(),
+  role: yup.string().oneOf(["country", "global"]).required(),
 });

--- a/service/translations/en.js
+++ b/service/translations/en.js
@@ -11,4 +11,7 @@ export default {
   invalid_refresh_token_error: "Refresh token invalid or already used",
   invalid_reset_password_token_error: "Invalid or expired reset password token",
   account_deactivated_error: "Your account has been deactivated",
+  invalid_admin_otp_error: "Invalid OTP",
+  too_many_otp_requests_error:
+    "Too many OTP requests made, please try again soon.",
 };

--- a/service/utils/errors.js
+++ b/service/utils/errors.js
@@ -79,3 +79,19 @@ export const accountDeactivated = (language) => {
   error.status = 401;
   return error;
 };
+
+export const invalidOTP = (language) => {
+  const error = new Error();
+  error.message = t("invalid_admin_otp_error", language);
+  error.name = "INVALID OTP";
+  error.status = 401;
+  return error;
+};
+
+export const tooManyOTPRequests = (language) => {
+  const error = new Error();
+  error.message = t("too_many_otp_requests_error", language);
+  error.name = "TOO MANY OTP REQUESTS";
+  error.status = 429;
+  return error;
+};

--- a/service/utils/helperFunctions.js
+++ b/service/utils/helperFunctions.js
@@ -12,3 +12,7 @@ export const updatePassword = async ({ admin_id, password }) => {
     throw err;
   });
 };
+
+export const generate4DigitCode = () => {
+  return Math.floor(Math.random() * 9000 + 1000);
+};


### PR DESCRIPTION
- Added a new endpoint to request 2FA OTP that is required when admin users login, OTP is sent to the user's email address
- Admin users now need to provide a 4-digit OTP during login
- 2FA OTP expires after 30 minutes from being sent
- Users can request 2FA OTP codes every 60 seconds as a security measure against DDOS attacks